### PR TITLE
Destroy Detector instance at the end to make valgrind happier

### DIFF
--- a/src/InitializeDD4hep.cc
+++ b/src/InitializeDD4hep.cc
@@ -73,5 +73,9 @@ void InitializeDD4hep::processEvent( LCEvent * ) { }
 
 void InitializeDD4hep::check( LCEvent *  ) { }
 
-void InitializeDD4hep::end(){ }
+void InitializeDD4hep::end(){
+
+  dd4hep::Detector::getInstance().destroyInstance();
+
+}
 


### PR DESCRIPTION
makes it also easier to spot other memory leaks



BEGINRELEASENOTES
- Destroy Detector instance at the end to make valgrind happier

ENDRELEASENOTES