### PR TITLE
Bump the minimum cmake version to 3.10 to allow building with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################
 # cmake file for building Marlin example Package
 # @author Jan Engels, Desy IT
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 ########################################################
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum cmake version to 3.10 to allow building with CMake 4

ENDRELEASENOTES